### PR TITLE
Add spec for HTML minification

### DIFF
--- a/__tests__/filters/html.spec.js
+++ b/__tests__/filters/html.spec.js
@@ -9,6 +9,20 @@ const originalContent =
   </body>
 </html>`
 
+
+test('minifies HTML code', async () => {
+  const ctx = await sandbox({fixtureName: 'html'});
+  mockConfig(ctx, 'asset_pipeline', {html_minifier: {enable: true}});
+
+  await process(ctx);
+
+  const content1 = await contentFor(ctx, 'test.html');
+  const content2 = await contentFor(ctx, 'test2.html');
+
+  expect(content1.toString().trim()).toBe('<html><body><h2>Hello</h2></body></html>');
+  expect(content2.toString().trim()).toBe('<html><body><h2>Hello too</h2></body></html>');
+});
+
 test('preserves original content when disabled', async () => {
   const ctx = await sandbox({fixtureName: 'html'});
   mockConfig(ctx, 'asset_pipeline', {html_minifier: {enable: false}});

--- a/__tests__/fixtures/html/source/test2.html
+++ b/__tests__/fixtures/html/source/test2.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    <h2>Hello too</h2>
+  </body>
+</html>

--- a/lib/filters/html.js
+++ b/lib/filters/html.js
@@ -2,22 +2,20 @@
 
 const Htmlminifier = require('html-minifier').minify;
 const minimatch = require('minimatch');
-let enable;
-let exclude;
-
+const cloneDeep = require('lodash.clonedeep');
 
 function run(str, data) {
   const hexo = this;
-  const options = hexo.config.asset_pipeline.html_minifier;
+  const options = cloneDeep(hexo.config.asset_pipeline.html_minifier);
   const path = data.path;
   const log = hexo.log || console;
 
   /**
-   * Cache enable and exclude then delete from options as they are not clean_css options.
+   * Cache enable and exclude then delete from options as they are not Htmlminifier options.
    */
-  enable = enable || options.enable;
+  let enable = options.enable;
   delete options.enable;
-  exclude = exclude || options.exclude;
+  let exclude = options.exclude;
   delete options.exclude;
 
   /**

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "imagemin-optipng": "^5.2.1",
     "imagemin-pngquant": "^5.0.1",
     "imagemin-svgo": "^6.0.0",
+    "lodash.clonedeep": "^4.5.0",
     "minimatch": "^3.0.4",
     "rev-path": "^2.0.0",
     "soup": "^0.1.5",


### PR DESCRIPTION
The `enable` and `exclude` option were cached on the module
level preventing spec to be run with different value - first
spec caused the cache to be written and the next spec
used the cached value.

Is there any reason to cache those config values on the module level?

Related to #20 