### PR TITLE
Add specs for clean css filter

### DIFF
--- a/__tests__/filters/css.spec.js
+++ b/__tests__/filters/css.spec.js
@@ -1,0 +1,32 @@
+const getSandbox = require('../support/sandbox');
+const {process, mockConfig, contentFor} = require('hexo-test-utils');
+const sandbox = getSandbox();
+
+const originalContent =
+`body {
+  background-color: red;
+}`
+
+test('minifies CSS code', async () => {
+  const ctx = await sandbox({fixtureName: 'css'});
+  mockConfig(ctx, 'asset_pipeline', {clean_css: {enable: true}});
+
+  await process(ctx);
+
+  const content1 = await contentFor(ctx, 'mystyle.css');
+  const content2 = await contentFor(ctx, 'mystyle2.css');
+
+  expect(content1.toString().trim()).toBe('body{background-color:red}');
+  expect(content2.toString().trim()).toBe('body{background-color:#ff0}');
+});
+
+test('preserves original content when disabled', async () => {
+  const ctx = await sandbox({fixtureName: 'css'});
+  mockConfig(ctx, 'asset_pipeline', {clean_css: {enable: false}});
+
+  await process(ctx);
+
+  const content = await contentFor(ctx, 'mystyle.css');
+
+  expect(content.toString().trim()).toBe(originalContent);
+});

--- a/__tests__/fixtures/css/_config.yml
+++ b/__tests__/fixtures/css/_config.yml
@@ -1,0 +1,1 @@
+theme: test

--- a/__tests__/fixtures/css/source/mystyle.css
+++ b/__tests__/fixtures/css/source/mystyle.css
@@ -1,0 +1,3 @@
+body {
+  background-color: red;
+}

--- a/__tests__/fixtures/css/source/mystyle2.css
+++ b/__tests__/fixtures/css/source/mystyle2.css
@@ -1,0 +1,3 @@
+body {
+  background-color: yellow;
+}

--- a/__tests__/fixtures/css/themes/test/layout/index.ejs
+++ b/__tests__/fixtures/css/themes/test/layout/index.ejs
@@ -1,0 +1,1 @@
+<%- page.content %>

--- a/lib/filters/css.js
+++ b/lib/filters/css.js
@@ -3,22 +3,20 @@
 const CleanCSS = require('clean-css');
 const minimatch = require('minimatch');
 const Promise = require('bluebird');
-let enable;
-let exclude;
-
+const cloneDeep = require('lodash.clonedeep');
 
 function run(str, data) {
   const hexo = this;
-  const options = hexo.config.asset_pipeline.clean_css;
+  const options = cloneDeep(hexo.config.asset_pipeline.clean_css);
   const path = data.path;
   const log = hexo.log || console;
 
   /**
    * Cache enable and exclude then delete from options as they are not clean_css options.
    */
-  enable = enable || options.enable;
+  let enable = options.enable;
   delete options.enable;
-  exclude = exclude || options.exclude;
+  let exclude = options.exclude;
   delete options.exclude;
 
   /**
@@ -26,7 +24,7 @@ function run(str, data) {
    */
   if (!enable) {
     log.info('Filter(asset_pipeline.clean_css) is not enabled.Skipping it.')
-    return Promise.resolve('Skipping asset_pipeline.clean_css.');
+    return str;
   }
 
   if (exclude && !Array.isArray(exclude)) exclude = [exclude];

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "imagemin-optipng": "^5.2.1",
     "imagemin-pngquant": "^5.0.1",
     "imagemin-svgo": "^6.0.0",
+    "lodash.clonedeep": "^4.5.0",
     "minimatch": "^3.0.4",
     "rev-path": "^2.0.0",
     "soup": "^0.1.5",


### PR DESCRIPTION
Similar to #24 
Related to #20

Same as for HTML filter, to be able to write specs for this filter I had to remove caching of `enable` and `exclude` options.