### PR TITLE
Add specs for JS filter

### DIFF
--- a/__tests__/filters/js.spec.js
+++ b/__tests__/filters/js.spec.js
@@ -1,0 +1,44 @@
+const getSandbox = require('../support/sandbox');
+const {process, mockConfig, contentFor} = require('hexo-test-utils');
+const sandbox = getSandbox();
+
+const originalContent =
+`function test() {
+  return { a: 5 }
+}
+
+test()`
+
+test('minifies JavaScript code', async () => {
+  const ctx = await sandbox({fixtureName: 'js'});
+  mockConfig(ctx, 'asset_pipeline', {uglify_js: {enable: true}});
+
+  await process(ctx);
+
+  const content1 = await contentFor(ctx, 'mycode.js');
+
+  expect(content1.toString().trim()).toBe('function test(){return{a:5}}test();');
+});
+
+test('preserves original content when disabled', async () => {
+  const ctx = await sandbox({fixtureName: 'js'});
+  mockConfig(ctx, 'asset_pipeline', {uglify_js: {enable: false}});
+
+  await process(ctx);
+
+  const content = await contentFor(ctx, 'mycode.js');
+
+  expect(content.toString().trim()).toBe(originalContent);
+});
+
+
+test('respects the exclude option', async () => {
+  const ctx = await sandbox({fixtureName: 'js'});
+  mockConfig(ctx, 'asset_pipeline', {uglify_js: {enable: true, exclude: ['**/mycode.js']}});
+
+  await process(ctx);
+
+  const content = await contentFor(ctx, 'mycode.js');
+
+  expect(content.toString().trim()).toBe(originalContent);
+});

--- a/__tests__/fixtures/css/_config.yml
+++ b/__tests__/fixtures/css/_config.yml
@@ -1,1 +1,0 @@
-theme: test

--- a/__tests__/fixtures/css/themes/test/layout/index.ejs
+++ b/__tests__/fixtures/css/themes/test/layout/index.ejs
@@ -1,1 +1,0 @@
-<%- page.content %>

--- a/__tests__/fixtures/js/source/mycode.js
+++ b/__tests__/fixtures/js/source/mycode.js
@@ -1,0 +1,5 @@
+function test() {
+  return { a: 5 }
+}
+
+test()

--- a/lib/filters/css.js
+++ b/lib/filters/css.js
@@ -14,9 +14,9 @@ function run(str, data) {
   /**
    * Cache enable and exclude then delete from options as they are not clean_css options.
    */
-  let enable = options.enable;
+  const enable = options.enable;
   delete options.enable;
-  let exclude = options.exclude;
+  const exclude = options.exclude;
   delete options.exclude;
 
   /**

--- a/lib/filters/html.js
+++ b/lib/filters/html.js
@@ -13,9 +13,9 @@ function run(str, data) {
   /**
    * Cache enable and exclude then delete from options as they are not Htmlminifier options.
    */
-  let enable = options.enable;
+  const enable = options.enable;
   delete options.enable;
-  let exclude = options.exclude;
+  const exclude = options.exclude;
   delete options.exclude;
 
   /**

--- a/lib/filters/js.js
+++ b/lib/filters/js.js
@@ -2,22 +2,22 @@
 
 const minimatch = require('minimatch');
 const UglifyJS = require('uglify-js');
-let enable;
-let exclude;
+const cloneDeep = require('lodash.clonedeep');
+
 
 
 function run(str, data) {
   const hexo = this;
-  const options = hexo.config.asset_pipeline.uglify_js;
+  const options = cloneDeep(hexo.config.asset_pipeline.uglify_js);
   const path = data.path;
   const log = hexo.log || console;
 
   /**
    * Cache enable and exclude then delete from options as they are not clean_css options.
    */
-  enable = enable || options.enable;
+  const enable = options.enable;
   delete options.enable;
-  exclude = exclude || options.exclude;
+  const exclude = options.exclude;
   delete options.exclude;
 
   /**
@@ -25,7 +25,7 @@ function run(str, data) {
    */
   if (!enable) {
     log.info('Filter(asset_pipeline.uglify_js) is not enabled.Skipping it.')
-    return Promise.resolve('Skipping asset_pipeline.uglify_js.');
+    return str;
   }
 
   if (exclude && !Array.isArray(exclude)) exclude = [exclude];

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "jest"
   },
   "jest": {
+    "testRegex": "/__tests__/.*.spec.js",
     "testPathIgnorePatterns": [
       "support/"
     ]


### PR DESCRIPTION
Fixed a bug for disabled filter - it used to output a single line
> Skipping asset_pipeline.uglify_js

Now it renders the original content.

Use `const` instead of `let` for enable and exclude options identifiers as
they do not change the value.