### PR TITLE
refactor: replace minimatch with micromatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ revisioning:
     'video[poster]': 'poster'
 ```
 
-#### Note: To match paths in `exclude` option, glob matching is done using [minmatch](https://github.com/isaacs/minimatch).
+#### Note: To match paths in `exclude` option, glob matching is done using [micromatch](https://github.com/micromatch/micromatch).
 
 #### TODO
 * Eslint configs

--- a/lib/filters/css.js
+++ b/lib/filters/css.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const CleanCSS = require('clean-css');
-const minimatch = require('minimatch');
+const micromatch = require('micromatch');
 const Promise = require('bluebird');
 const cloneDeep = require('lodash.clonedeep');
 
@@ -27,12 +27,8 @@ function run(str, data) {
     return str;
   }
 
-  if (exclude && !Array.isArray(exclude)) exclude = [exclude];
-
   if (path && exclude && exclude.length) {
-    for (let i = 0, len = exclude.length; i < len; i++) {
-      if (minimatch(path, exclude[i])) return str;
-    }
+    if (micromatch.isMatch(path, exclude, { basename: true })))) return str;
   }
 
   return new Promise(function(resolve, reject) {

--- a/lib/filters/css.js
+++ b/lib/filters/css.js
@@ -28,7 +28,7 @@ function run(str, data) {
   }
 
   if (path && exclude && exclude.length) {
-    if (micromatch.isMatch(path, exclude, { basename: true })))) return str;
+    if (micromatch.isMatch(path, exclude, { basename: true })) return str;
   }
 
   return new Promise(function(resolve, reject) {

--- a/lib/filters/html.js
+++ b/lib/filters/html.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Htmlminifier = require('html-minifier').minify;
-const minimatch = require('minimatch');
+const micromatch = require('micromatch');
 const cloneDeep = require('lodash.clonedeep');
 
 function run(str, data) {
@@ -26,12 +26,8 @@ function run(str, data) {
     return str;
   }
 
-  if (exclude && !Array.isArray(exclude)) exclude = [exclude];
-
   if (path && exclude && exclude.length) {
-    for (let i = 0, len = exclude.length; i < len; i++) {
-      if (minimatch(path, exclude[i])) return str;
-    }
+    if (micromatch.isMatch(path, exclude, { basename: true })) return str;
   }
 
   let result = str;

--- a/lib/filters/image.js
+++ b/lib/filters/image.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const minimatch = require('minimatch');
+const micromatch = require('micromatch');
 const Promise = require('bluebird');
 const Imagemin = require('imagemin');
 const mozjpeg = require('imagemin-mozjpeg');
@@ -52,7 +52,7 @@ function run(str, data) {
 
   // exclude image
   const routes = route.list().filter(function(path) {
-    return minimatch(path, '**/*.{' + targetfile.join(',') + '}', {
+    return micromatch.isMatch(path, '**/*.{' + targetfile.join(',') + '}', {
       nocase: true
     });
   });

--- a/lib/filters/js.js
+++ b/lib/filters/js.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const minimatch = require('minimatch');
+const micromatch = require('micromatch');
 const UglifyJS = require('uglify-js');
 const cloneDeep = require('lodash.clonedeep');
 
@@ -28,12 +28,8 @@ function run(str, data) {
     return str;
   }
 
-  if (exclude && !Array.isArray(exclude)) exclude = [exclude];
-
   if (path && exclude && exclude.length) {
-    for (let i = 0, len = exclude.length; i < len; i++) {
-      if (minimatch(path, exclude[i])) return str;
-    }
+    if (micromatch.isMatch(path, exclude, { basename: true })) return str;
   }
 
   const result = UglifyJS.minify(str, options);

--- a/lib/revision.js
+++ b/lib/revision.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const path = require('path');
-const minimatch = require('minimatch');
+const micromatch = require('micromatch');
 const Promise = require('bluebird');
 const hasha = require('hasha');
 const revPath = require('rev-path');
@@ -66,14 +66,10 @@ function run() {
       /**
        * Skip excluded files.
        * */
-      if (exclude && !Array.isArray(exclude)) exclude = [exclude];
-
       if (path && exclude && exclude.length) {
-        for (let i = 0, len = exclude.length; i < len; i++) {
-          if (minimatch(path, exclude[i])){
-            // console.log('[revision]Ignoring '+ path)
-            return false;
-          }
+        if (micromatch.isMatch(path, exclude, { basename: true })) {
+          // console.log('[revision]Ignoring '+ path)
+          return false;
         }
       }
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "imagemin-pngquant": "^8.0.0",
     "imagemin-svgo": "^7.0.0",
     "lodash.clonedeep": "^4.5.0",
-    "minimatch": "^3.0.4",
+    "micromatch": "^4.0.2",
     "rev-path": "^2.0.0",
     "soup": "^0.1.5",
     "stream-to-array": "^2.3.0",


### PR DESCRIPTION
https://github.com/hexojs/hexo/pull/3538

Note that `*.js` requires `basename / matchBase` option, unless `**/*.js` pattern is used, like in "lib/filters/image.js" .